### PR TITLE
fix sway-user-service script

### DIFF
--- a/bin/sway-user-service
+++ b/bin/sway-user-service
@@ -4,10 +4,10 @@
 
 # robustness: if the previous graphical session left some failed units,
 # reset them so that they don't break this startup
-for unit in $(systemctl --user --no-legend --state=failed list-units | cut-f1 -d''); do
+for unit in $(systemctl --user --no-legend --state=failed list-units | cut -f1 -d' '); do
 	partof="$(systemctl --user show -p PartOf --value)"
-	if [ "$partof" = "graphical-session.target" ] || [ "$partof" = "wayland-session.target"]; then
-		systemctl --user reset-failed $unit
+	if [ "$partof" = "graphical-session.target" ] || [ "$partof" = "wayland-session.target" ]; then
+		systemctl --user reset-failed "$unit"
 	fi
 done
 


### PR DESCRIPTION
- fix `cut` call
- need space before `]`
- prevent word splitting `$unit` by wrapping in quotes 