### PR TITLE
Introduce oguri.service

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ wayland exclusive services
 * `sway.service`
 * `kanshi.service`
 * `mako.service`
+* `oguri.service`
 * `swayidle.service`
 
 ## Notes

--- a/systemd/meson.build
+++ b/systemd/meson.build
@@ -1,6 +1,7 @@
 services = [
   'kanshi.service',
   'mako.service',
+  'oguri.service',
   'sway-session-pre.target',
   'sway-session.target',
   'sway.service',

--- a/systemd/oguri.service
+++ b/systemd/oguri.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=An animated wallpaper daemon for Wayland compositors
+Documentation=https://github.com/vilhalmer/oguri
+PartOf=wayland-session.target
+Requires=wayland-session.target
+After=wayland-session.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/oguri
+
+[Install]
+WantedBy=wayland-session.target


### PR DESCRIPTION
Oguri is a nice wallpaper deamon for Wayland compositors with support
for static as well as animated wallpapers.

This commit introduces the first version of a systemd config.

See [oguri](https://github.com/vilhalmer/oguri)