### PR TITLE
Remove mako reference from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ wayland exclusive services
 
 * `sway.service`
 * `kanshi.service`
-* `mako.service`
 * `oguri.service`
 * `swayidle.service`
 


### PR DESCRIPTION
The service file was recently removed due to now existing upstream.