### PR TITLE
config/sway: only talk to systemd if running as a service

### DIFF
--- a/config/sway/10-service.conf
+++ b/config/sway/10-service.conf
@@ -1,6 +1,7 @@
 # Import variables set-up by sway into the environment and notify systemd that
 # sway is ready.
-exec systemctl --user import-environment SWAYSOCK \
+exec test -n "$$NOTIFY_SOCKET" \
+  && systemctl --user import-environment SWAYSOCK \
 					 DISPLAY \
 					 I3SOCK \
 					 WAYLAND_DISPLAY \


### PR DESCRIPTION
When systemd launches sway as a service, it will set `NOTIFY_SOCKET` so that sway may execute systemd-notify when it's ready.  Putting this config file in /etc/sway/config.d, however, implies that it may be loaded by all sway instances, whether or not they are run as a systemd service (e.g. greetd running sway for gtkgreet).  We can check if `NOTIFY_SOCKET` is set before talking to systemd to accommodate this situation.