### PR TITLE
feat: add alternative starter for --unsupported-gpu

### DIFF
--- a/bin/sway-user-service
+++ b/bin/sway-user-service
@@ -22,13 +22,17 @@ source /etc/profile
 export XDG_CURRENT_DESKTOP=sway
 
 # save environment variables that will be added to systemd
-new_env=$(systemctl --user show-environment | cut -d'=' -f 1 | sort | comm -13 - <(env | cut -d'=' -f 1 | sort))
+new_env=$(systemctl --user show-environment | cut -d'=' -f 1 | sort | comm -13 - <(env | cut -d'=' -f 1 | sort | tr '\n' ' '))
 
 # import environment variables from the login manager
-systemctl --user import-environment
+# shellcheck disable=SC2086
+systemctl --user import-environment $new_env
+systemctl --user set-environment SWAY_CMD="/usr/bin/sway $*"
 
 # then start the service
+# pass on parameters to the sway command to be picked up
 systemctl --wait --user start sway.service
 
 # cleanup environment
+# shellcheck disable=SC2086
 systemctl --user unset-environment $new_env

--- a/systemd/sway.service
+++ b/systemd/sway.service
@@ -11,7 +11,7 @@ Before=sway-session.target
 [Service]
 Type=notify
 EnvironmentFile=-%h/.config/sway/env
-ExecStart=/usr/bin/sway
+ExecStart=sh -c "${SWAY_CMD}"
 Restart=on-failure
 RestartSec=1
 TimeoutStopSec=10

--- a/wayland-sessions/meson.build
+++ b/wayland-sessions/meson.build
@@ -1,5 +1,6 @@
 desktop_files = [
   'sway-session.desktop',
+  'sway-session-unsupported-gpu.desktop'
 ]
 
 install_data(desktop_files, install_dir: 'share/wayland-sessions')

--- a/wayland-sessions/sway-session-unsupported-gpu.desktop
+++ b/wayland-sessions/sway-session-unsupported-gpu.desktop
@@ -1,0 +1,7 @@
+# This file is mostly inspired from https://github.com/swaywm/sway/wiki/Systemd-integration
+
+[Desktop Entry]
+Name=Sway Service (--unsupported-gpu)
+Comment=SirCmpwn's Wayland window manager as a systemd service
+Exec=sway-user-service --unsupported-gpu
+Type=Application


### PR DESCRIPTION
The idea is to provide an easy way for nvidia users to use sway by passing `--unsupported-gpu`. Could be a nice for other use-cases too.